### PR TITLE
fix(boot): user brokerUrl when no microservices options provided

### DIFF
--- a/packages/boot/fixtures/asyncapi.json
+++ b/packages/boot/fixtures/asyncapi.json
@@ -28,10 +28,7 @@
             "description": "Example has been verified"
           }
         },
-        "required": [
-          "name",
-          "verified"
-        ]
+        "required": ["name", "verified"]
       }
     }
   },

--- a/packages/boot/fixtures/openapi.json
+++ b/packages/boot/fixtures/openapi.json
@@ -67,10 +67,7 @@
             "description": "Example has been verified"
           }
         },
-        "required": [
-          "name",
-          "verified"
-        ]
+        "required": ["name", "verified"]
       }
     }
   },

--- a/packages/boot/src/boot.ts
+++ b/packages/boot/src/boot.ts
@@ -283,7 +283,7 @@ export class ApplicationBoot<Conf extends BaseConfig> extends EventEmitter {
       if (this.options.openApi) {
         await this.setupOpenApi();
       }
-      if (this.options.enableMicroservices && this.config.microservices?.length && this.options.asyncApi) {
+      if (this.options.asyncApi) {
         await this.setupAsyncApi();
       }
       if (typeof setupOptions.postSetup === 'function') {


### PR DESCRIPTION
# Description

Allow to generate AsyncAPI specs when no microservices options are provided by the publisher (only) app.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
