### PR TITLE
fix: improve amqp channel setup error handling

### DIFF
--- a/packages/amqp-transport/src/amqp-server.ts
+++ b/packages/amqp-transport/src/amqp-server.ts
@@ -14,6 +14,7 @@ import {
   DISCONNECTED_RMQ_MESSAGE,
   NO_MESSAGE_HANDLER,
   RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT,
+  RQM_DEFAULT_NO_ASSERT,
   RQM_DEFAULT_NOACK,
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE_OPTIONS,
@@ -38,15 +39,21 @@ export enum AmqpWildcard {
   MULTI_LEVEL = '#',
 }
 
+const INFINITE_CONNECTION_ATTEMPTS = -1;
+
 export class AmqpServer extends Server implements CustomTransportStrategy {
   readonly transportId?: Transport;
   private channel: ChannelWrapper = null;
   private server: AmqpConnectionManager = null;
+  private connectionAttempts = 0;
+
   private urls: string[] | RmqUrl[];
   private queue: string;
   private queueOptions: Options.AssertQueue;
   private prefetchCount: number;
   private isGlobalPrefetchCount: boolean;
+  private noAssert: boolean;
+
   private exchange?: string;
   private exchangeType?: 'direct' | 'fanout' | 'topic';
   private exchangeOptions?: Options.AssertExchange;
@@ -65,6 +72,8 @@ export class AmqpServer extends Server implements CustomTransportStrategy {
     this.prefetchCount = this.getOptionsProp(this.options, 'prefetchCount') || RQM_DEFAULT_PREFETCH_COUNT;
     this.isGlobalPrefetchCount =
       this.getOptionsProp(this.options, 'isGlobalPrefetchCount') || RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT;
+    this.noAssert = this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
+
     this.initializeSerializer(options);
     this.initializeDeserializer(options);
   }
@@ -82,7 +91,7 @@ export class AmqpServer extends Server implements CustomTransportStrategy {
     this.server && this.server.close();
   }
 
-  async start(callback: (error?: Error) => void): Promise<void> {
+  async start(callback?: (error?: unknown) => void): Promise<void> {
     this.server = this.createClient();
     this.server.on(CONNECT_EVENT, () => {
       if (this.channel) {
@@ -93,13 +102,30 @@ export class AmqpServer extends Server implements CustomTransportStrategy {
         setup: (channel: Channel) => this.setupChannel(channel, callback),
       });
     });
+
+    const maxConnectionAttempts = this.getOptionsProp(
+      this.options,
+      'maxConnectionAttempts',
+      INFINITE_CONNECTION_ATTEMPTS,
+    );
+
     this.server.on(DISCONNECT_EVENT, (err) => {
       this.logger.error(DISCONNECTED_RMQ_MESSAGE);
       this.logger.error(err);
     });
-    this.server.on(CONNECT_FAILED_EVENT, (err) => {
+    this.server.on(CONNECT_FAILED_EVENT, (error: Record<string, unknown>) => {
       this.logger.error(CONNECT_FAILED_EVENT_MSG);
-      this.logger.error(err);
+      if (error?.err) {
+        this.logger.error(error.err);
+      }
+      const isReconnecting = !!this.channel;
+      if (maxConnectionAttempts === INFINITE_CONNECTION_ATTEMPTS || isReconnecting) {
+        return;
+      }
+      if (++this.connectionAttempts === maxConnectionAttempts) {
+        this.close();
+        callback?.(error.err ?? new Error(CONNECT_FAILED_EVENT_MSG));
+      }
     });
   }
 
@@ -132,12 +158,12 @@ export class AmqpServer extends Server implements CustomTransportStrategy {
   async setupChannel(channel: Channel, callback: (error?: Error) => void, retried?: boolean): Promise<void> {
     try {
       const noAck = this.getOptionsProp(this.options, 'noAck', RQM_DEFAULT_NOACK);
-      if (this.exchange) {
+      if (this.exchange && !this.noAssert) {
         await channel.assertExchange(this.exchange, this.exchangeType, this.exchangeOptions);
         const q = await channel.assertQueue(this.queue, this.queueOptions);
         const registeredPatterns = [...this.messageHandlers.keys()];
         await Promise.all(registeredPatterns.map((pattern) => channel.bindQueue(q.queue, this.exchange, pattern)));
-      } else {
+      } else if (!this.noAssert) {
         await channel.assertQueue(this.queue, this.queueOptions);
       }
 
@@ -206,7 +232,7 @@ export class AmqpServer extends Server implements CustomTransportStrategy {
     }
     const { content, properties } = message;
     const rawMessage = JSON.parse(content.toString());
-    const packet = await this.deserializer.deserialize(rawMessage);
+    const packet = await this.deserializer.deserialize(rawMessage, properties);
     const pattern = isString(packet.pattern) ? packet.pattern : JSON.stringify(packet.pattern);
     const rmqContext = new RmqContext([message, channel, pattern]);
     if (isUndefined((packet as IncomingRequest).id)) {

--- a/packages/amqp-transport/src/amqp.interfaces.ts
+++ b/packages/amqp-transport/src/amqp.interfaces.ts
@@ -9,6 +9,8 @@ export interface AmqpOptions {
   queue?: string;
   prefetchCount?: number;
   isGlobalPrefetchCount?: boolean;
+  noAssert?: boolean;
+  maxConnectionAttempts?: number;
   queueOptions?: Options.AssertQueue;
   socketOptions?: (ConnectionOptions | TcpSocketConnectOpts) & {
     noDelay?: boolean;


### PR DESCRIPTION
# Description

- [x] properly handle `setupChannel` errors
- [x] follow latest changes from [server-rmq](https://github.com/nestjs/nest/blob/master/packages/microservices/server/server-rmq.ts) and [client-rmq](https://github.com/nestjs/nest/blob/master/packages/microservices/client/client-rmq.ts) from NestJS

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
