### PR TITLE
feat(boot): override NestJS app options

### DIFF
--- a/packages/boot/src/boot.ts
+++ b/packages/boot/src/boot.ts
@@ -10,6 +10,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 import { AsyncAPIObject } from 'nestjs-asyncapi';
+import { URL } from 'url';
 
 import { getMainServerUrl, setupAsyncApi, setupOpenApi } from './api-specs';
 import { BaseConfig, BootOptions, defaultOptions, SetupOptions } from './options';
@@ -98,10 +99,13 @@ export class ApplicationBoot<Conf extends BaseConfig> extends EventEmitter {
   logInfo(): void {
     const { asyncApi, openApi, serviceName } = this.options;
     const { asyncApiPath, brokerUrl, environment, swaggerPath } = this.config;
+    const brokerUrlObject = new URL(brokerUrl);
+    brokerUrlObject.username = '*****';
+    brokerUrlObject.password = '*****';
     const logger = this.logger;
     const url = getMainServerUrl(this.config);
-    logger.log(chalk.blue.bold(`✅ ${serviceName} microservice running on 👉 ${url}`), 'Bootstrap');
-    logger.log(chalk.blue.bold(`✅ ${serviceName} microservice connecting to 👉 ${brokerUrl}`), 'Bootstrap');
+    logger.log(chalk.blue.bold(`✅ ${serviceName} microservice running on 👉 ${url}`));
+    logger.log(chalk.blue.bold(`✅ ${serviceName} microservice connecting to 👉 ${brokerUrlObject.href}`));
     if (openApi?.enableExplorer) {
       logger.log(chalk.green.bold(`📄 Swagger 👉 ${url}/${swaggerPath}`));
     }

--- a/packages/boot/src/options.ts
+++ b/packages/boot/src/options.ts
@@ -3,6 +3,7 @@ import type {
   ExceptionFilter,
   LoggerService,
   LogLevel,
+  NestApplicationOptions,
   NestHybridApplicationOptions,
   NestInterceptor,
   PipeTransform,
@@ -87,6 +88,7 @@ export type BootOptions<Config extends BaseConfig> = {
   AppModule: Function; // eslint-disable-line @typescript-eslint/ban-types
   openApi?: OpenApiOptions;
   asyncApi?: AsyncApiOptions;
+  loggerName?: string;
   logger?: LoggerService;
   logLevels?: LogLevel[];
   staticAssets?: { path: string; options?: ServeStaticOptions }[];
@@ -167,7 +169,7 @@ export const defaultOptions: BootOptions<BaseConfig> = {
   rateLimitOptions: false,
 };
 
-export interface SetupOptions {
+export interface SetupOptions extends NestApplicationOptions {
   workerId?: number;
   preSetup?: (app?: NestExpressApplication) => Promise<void> | void;
   postSetup?: (app?: NestExpressApplication) => Promise<void> | void;


### PR DESCRIPTION
# Description

- Allow to override options passed to NestFactory.create, for cases such as custom logger usage.
- Hide broker URL credentials

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
