### PR TITLE
feat(amqp-transport): granular assertions

### DIFF
--- a/packages/amqp-transport/src/amqp.interfaces.ts
+++ b/packages/amqp-transport/src/amqp.interfaces.ts
@@ -19,6 +19,9 @@ export interface AmqpOptions {
   exchangeOptions?: Options.AssertExchange;
   noAck?: boolean;
   noAssert?: boolean;
+  noQueueAssert?: boolean;
+  noReplyQueueAssert?: boolean;
+  noExchangeAssert?: boolean;
   deleteChannelOnFailure?: boolean;
   socketOptions?: (ConnectionOptions | TcpSocketConnectOpts) & {
     noDelay?: boolean;

--- a/packages/amqp-transport/test/amqp.integration.spec.ts
+++ b/packages/amqp-transport/test/amqp.integration.spec.ts
@@ -35,11 +35,12 @@ const buildClientModule = (opts: BuildClientModuleOptions = {}): DynamicModule =
     urls: [opts.brokerUrl || RMQ_URL],
     queue: opts.queue || DUMMY_QUEUE,
     queueOptions: opts.queueOptions || {
-      durable: true,
+      durable: false,
       autoDelete: true,
     },
     replyQueue: opts.replyQueue || '',
     replyQueueOptions: opts.replyQueueOptions || {
+      durable: false,
       autoDelete: true,
     },
     prefetchCount: opts.prefetchCount || RQM_DEFAULT_PREFETCH_COUNT,
@@ -59,7 +60,7 @@ const createNestMicroserviceOptions = (options: AmqpOptions = {}) => {
     urls: [RMQ_URL],
     queue: DUMMY_QUEUE,
     queueOptions: {
-      durable: true,
+      durable: false,
       autoDelete: true,
     },
     // persistent: true,
@@ -405,7 +406,7 @@ describe('AMQP tests', () => {
       testConfiguration: {
         noAck,
         prefetchCount: 1,
-        replyQueueOptions: { exclusive: true, autoDelete: true },
+        replyQueueOptions: { exclusive: true, autoDelete: true, durable: false },
       },
       producersCount: 2,
     });
@@ -430,7 +431,7 @@ describe('AMQP tests', () => {
     });
   });
 
-  it('should response single producer with fixed replyQueue name ', async () => {
+  it('should reply to single producer with fixed replyQueue name ', async () => {
     // Given
     const noAck = true;
     const msg = { message };
@@ -456,7 +457,7 @@ describe('AMQP tests', () => {
     });
   });
 
-  it('should timeout with multiple producer with fixed replyQueue name ', async () => {
+  it('should timeout with multiple producer with identical replyQueue name', async () => {
     // Given
     const noAck = true;
     const msg = { message };


### PR DESCRIPTION
# Description

Allow to select which options for which assertion will be skipped:
- queue (`noQueueAssert`)
- exchange (`noExchangeAssert`)
- replyQueue (`noReplyQueueAssert`)
- all of the above (`noAssert`)

Ensure that channel is connected before setting the consumer (waiting for `replyQueue` value to be set).

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
