### PR TITLE
feat(nestjs-tools-file-storage): add S3-compatible service support for DigitalOcean Spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16486,10 +16486,10 @@
     },
     "packages/amqp-transport": {
       "name": "@getlarge/nestjs-tools-amqp-transport",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getlarge/typed-event-emitter": "0.2.0",
+        "@getlarge/typed-event-emitter": "0.2.1",
         "tslib": "^2.3.0",
         "uuid": "^9.0.1"
       },
@@ -16504,7 +16504,7 @@
     },
     "packages/async-local-storage": {
       "name": "@getlarge/nestjs-tools-async-local-storage",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -16517,16 +16517,16 @@
     },
     "packages/cluster": {
       "name": "@getlarge/nestjs-tools-cluster",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getlarge/typed-event-emitter": "0.2.0",
+        "@getlarge/typed-event-emitter": "0.2.1",
         "tslib": "^2.3.0"
       }
     },
     "packages/eslint-plugin": {
       "name": "@getlarge/eslint-plugin-nestjs-tools",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/utils": "^8.13.0",
@@ -16541,7 +16541,7 @@
     },
     "packages/fastify-upload": {
       "name": "@getlarge/nestjs-tools-fastify-upload",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -16556,7 +16556,7 @@
     },
     "packages/file-storage": {
       "name": "@getlarge/nestjs-tools-file-storage",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -16581,7 +16581,7 @@
     },
     "packages/lock": {
       "name": "@getlarge/nestjs-tools-lock",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "redlock": "^5.0.0-beta.2",
@@ -16594,7 +16594,7 @@
     },
     "packages/typed-event-emitter": {
       "name": "@getlarge/typed-event-emitter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
**Changes:**
- Add endpoint configuration with virtual-hosted-style URLs support
- Enhance region extraction to handle DigitalOcean Spaces endpoints
- Set forcePathStyle to false for S3-compatible services
- Bump package versions across monorepo (file-storage: 1.4.1 → 1.4.2)
- Update typed-event-emitter dependency (0.2.0 → 0.2.1)

This enables the file-storage package to work with S3-compatible services like DigitalOcean Spaces by properly configuring endpoint URLs and region extraction from non-AWS S3 endpoints.