### PR TITLE
fix(file-storage): forward endpoint and support OVH/DigitalOcean S3

### DIFF
--- a/packages/file-storage/src/lib/file-storage-s3.class.ts
+++ b/packages/file-storage/src/lib/file-storage-s3.class.ts
@@ -88,19 +88,16 @@ export class FileStorageS3 implements FileStorage {
   static extractRegionFromEndpoint(endpoint: string): string | null {
     if (!endpoint) return null;
     const host = endpoint.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
-    const patterns: RegExp[] = [
-      // AWS: s3.<region>.amazonaws.com  |  <bucket>.s3.<region>.amazonaws.com
-      /(?:^|\.)s3[.-]([^.]+)\.amazonaws\.com$/,
-      // OVH: s3.<region>.(perf.)?cloud.ovh.net
-      /^s3\.([^.]+)\.(?:perf\.)?cloud\.ovh\.net$/,
-      // DigitalOcean Spaces: <region>.digitaloceanspaces.com
-      /^([^.]+)\.digitaloceanspaces\.com$/,
-    ];
-    for (const re of patterns) {
-      const m = host.match(re);
-      if (m) return m[1];
-    }
-    return null;
+    // OVH: s3.<region>.(perf.)?cloud.ovh.net
+    const ovh = host.match(/^s3\.([^.]+)\.(?:perf\.)?cloud\.ovh\.net$/);
+    if (ovh) return ovh[1];
+    // DigitalOcean Spaces: <region>.digitaloceanspaces.com
+    const doSpaces = host.match(/^([^.]+)\.digitaloceanspaces\.com$/);
+    if (doSpaces) return doSpaces[1];
+    // AWS: last dotted segment before `.amazonaws.com` across all variants
+    // (s3, s3-fips, s3.dualstack, s3-control, s3-accesspoint, virtual-hosted, etc.)
+    const aws = host.match(/(?<=\.)[^.]+(?=\.amazonaws\.com$)/);
+    return aws?.length ? aws[0] : null;
   }
 
   transformFilePath(

--- a/packages/file-storage/src/lib/file-storage-s3.class.ts
+++ b/packages/file-storage/src/lib/file-storage-s3.class.ts
@@ -23,10 +23,12 @@ import { loadPackage } from './helpers';
 import { FileStorageWritable, MethodTypes, Request } from './types';
 
 function config(setup: FileStorageS3Setup) {
-  const { bucket, maxPayloadSize, credentials, endpoint, logger } = setup;
+  const { bucket, maxPayloadSize, credentials, endpoint, forcePathStyle, logger } = setup;
   const region = setup.region ?? FileStorageS3.extractRegionFromEndpoint(endpoint ?? '');
   if (!region) {
-    throw new Error('AWS region is missing');
+    throw new Error(
+      'AWS region is missing: pass `region` explicitly or use an endpoint whose region can be auto-extracted',
+    );
   }
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const loaderFn = (): { S3: typeof import('@aws-sdk/client-s3').S3 } => require('@aws-sdk/client-s3');
@@ -38,6 +40,8 @@ function config(setup: FileStorageS3Setup) {
      */
     ...(credentials ? { credentials } : {}),
     region,
+    ...(endpoint ? { endpoint } : {}),
+    ...(forcePathStyle !== undefined ? { forcePathStyle } : {}),
     ...(logger ? { logger } : {}),
   });
 
@@ -70,9 +74,33 @@ export class FileStorageS3 implements FileStorage {
     this.config = typeof factory === 'function' ? factory(setup) : config(setup);
   }
 
+  /**
+   * Auto-extracts the region from well-known S3-compatible endpoint shapes.
+   *
+   * Supported providers:
+   * - AWS S3: `s3.<region>.amazonaws.com` and `<bucket>.s3.<region>.amazonaws.com`
+   * - OVH Object Storage: `s3.<region>.cloud.ovh.net` and `s3.<region>.perf.cloud.ovh.net`
+   * - DigitalOcean Spaces: `<region>.digitaloceanspaces.com`
+   *
+   * Returns `null` if the endpoint does not match any known shape — in that case
+   * callers must pass `region` explicitly alongside `endpoint`.
+   */
   static extractRegionFromEndpoint(endpoint: string): string | null {
-    const match = endpoint?.match(/(?<=\.)[^.]+(?=\.amazonaws\.com)/);
-    return match?.length ? match[0] : null;
+    if (!endpoint) return null;
+    const host = endpoint.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    const patterns: RegExp[] = [
+      // AWS: s3.<region>.amazonaws.com  |  <bucket>.s3.<region>.amazonaws.com
+      /(?:^|\.)s3[.-]([^.]+)\.amazonaws\.com$/,
+      // OVH: s3.<region>.(perf.)?cloud.ovh.net
+      /^s3\.([^.]+)\.(?:perf\.)?cloud\.ovh\.net$/,
+      // DigitalOcean Spaces: <region>.digitaloceanspaces.com
+      /^([^.]+)\.digitaloceanspaces\.com$/,
+    ];
+    for (const re of patterns) {
+      const m = host.match(re);
+      if (m) return m[1];
+    }
+    return null;
   }
 
   transformFilePath(

--- a/packages/file-storage/src/lib/file-storage-s3.class.ts
+++ b/packages/file-storage/src/lib/file-storage-s3.class.ts
@@ -87,7 +87,15 @@ export class FileStorageS3 implements FileStorage {
    */
   static extractRegionFromEndpoint(endpoint: string): string | null {
     if (!endpoint) return null;
-    const host = endpoint.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    // Parse with URL when a scheme is present; fall back to the raw string
+    // (treated as a host) otherwise. Avoids regex-based stripping that
+    // CodeQL flags as a polynomial ReDoS risk.
+    let host: string;
+    try {
+      host = new URL(endpoint.includes('://') ? endpoint : `https://${endpoint}`).hostname;
+    } catch {
+      return null;
+    }
     // OVH: s3.<region>.(perf.)?cloud.ovh.net
     const ovh = host.match(/^s3\.([^.]+)\.(?:perf\.)?cloud\.ovh\.net$/);
     if (ovh) return ovh[1];

--- a/packages/file-storage/src/lib/file-storage-s3.types.ts
+++ b/packages/file-storage/src/lib/file-storage-s3.types.ts
@@ -24,11 +24,24 @@ import type {
 } from './file-storage.types';
 
 /**
- * Either region or endpoint must be provided
+ * At least one of `region` or `endpoint` must be provided.
+ *
+ * - `region` alone targets AWS S3 in that region.
+ * - `endpoint` alone targets an S3-compatible provider; the region is auto-extracted
+ *   from well-known endpoint shapes (AWS, OVH, DigitalOcean Spaces). If extraction
+ *   fails, pass `region` explicitly alongside `endpoint`.
+ * - Both together are valid and required for most S3-compatible providers, since
+ *   SigV4 signing always needs a region regardless of endpoint.
+ *
+ * `forcePathStyle` is forwarded to the underlying S3 client — enable it for
+ * providers that do not support virtual-hosted style addressing (e.g. MinIO).
  */
 export type FileStorageS3Setup = {
   bucket: string;
   maxPayloadSize: number;
+  region?: string;
+  endpoint?: string;
+  forcePathStyle?: boolean;
   credentials?: {
     accessKeyId: string;
     secretAccessKey: string;
@@ -36,7 +49,7 @@ export type FileStorageS3Setup = {
   };
   logger?: S3['config']['logger'];
   [key: string]: unknown;
-} & ({ region: string; endpoint?: never } | { endpoint: string; region?: never });
+} & ({ region: string } | { endpoint: string });
 
 export interface FileStorageS3Config {
   s3: S3;

--- a/packages/file-storage/test/file-storage-s3.unit.spec.ts
+++ b/packages/file-storage/test/file-storage-s3.unit.spec.ts
@@ -1,0 +1,84 @@
+import { FileStorageS3 } from '../src/lib/file-storage-s3.class';
+
+describe('FileStorageS3.extractRegionFromEndpoint', () => {
+  const cases: Array<[string, string | null]> = [
+    // AWS
+    ['https://s3.eu-west-1.amazonaws.com', 'eu-west-1'],
+    ['https://my-bucket.s3.us-east-2.amazonaws.com', 'us-east-2'],
+    ['s3.ap-southeast-1.amazonaws.com', 'ap-southeast-1'],
+    // OVH
+    ['https://s3.gra.perf.cloud.ovh.net', 'gra'],
+    ['https://s3.gra.cloud.ovh.net', 'gra'],
+    ['https://s3.sbg.cloud.ovh.net/some/path', 'sbg'],
+    // DigitalOcean Spaces
+    ['https://fra1.digitaloceanspaces.com', 'fra1'],
+    ['nyc3.digitaloceanspaces.com', 'nyc3'],
+    // Unknown / unsupported
+    ['https://minio.local:9000', null],
+    ['https://storage.googleapis.com', null],
+    ['', null],
+  ];
+
+  it.each(cases)('%s -> %s', (endpoint, expected) => {
+    expect(FileStorageS3.extractRegionFromEndpoint(endpoint)).toBe(expected);
+  });
+});
+
+// eslint-disable-next-line max-lines-per-function
+describe('FileStorageS3 constructor wiring', () => {
+  it('throws when neither region nor extractable endpoint is provided', () => {
+    expect(
+      () =>
+        new FileStorageS3({
+          bucket: 'b',
+          maxPayloadSize: 1,
+          endpoint: 'https://minio.local:9000',
+        } as never),
+    ).toThrow(/region is missing/i);
+  });
+
+  it('accepts an AWS endpoint and derives the region', () => {
+    const fs = new FileStorageS3({
+      bucket: 'b',
+      maxPayloadSize: 1,
+      endpoint: 'https://s3.eu-west-1.amazonaws.com',
+    } as never);
+    expect(fs.config.s3.config.region).toBeDefined();
+  });
+
+  it('forwards endpoint to the underlying S3 client', async () => {
+    const fs = new FileStorageS3({
+      bucket: 'b',
+      maxPayloadSize: 1,
+      endpoint: 'https://s3.gra.perf.cloud.ovh.net',
+    } as never);
+    const endpoint = await fs.config.s3.config.endpoint?.();
+    expect(endpoint).toBeDefined();
+    expect(endpoint?.hostname).toBe('s3.gra.perf.cloud.ovh.net');
+  });
+
+  it('forwards forcePathStyle to the underlying S3 client', async () => {
+    const fs = new FileStorageS3({
+      bucket: 'b',
+      maxPayloadSize: 1,
+      region: 'us-east-1',
+      endpoint: 'https://minio.local:9000',
+      forcePathStyle: true,
+    } as never);
+    const fps = fs.config.s3.config.forcePathStyle;
+    const resolved = typeof fps === 'function' ? await (fps as () => Promise<boolean>)() : fps;
+    expect(resolved).toBe(true);
+  });
+
+  it('accepts region and endpoint together (SigV4 requires region)', async () => {
+    const fs = new FileStorageS3({
+      bucket: 'b',
+      maxPayloadSize: 1,
+      region: 'us-east-1',
+      endpoint: 'https://minio.local:9000',
+    } as never);
+    expect(await fs.config.s3.config.region()).toBe('us-east-1');
+    const endpoint = await fs.config.s3.config.endpoint?.();
+    expect(endpoint?.hostname).toBe('minio.local');
+  });
+});


### PR DESCRIPTION
## Summary

- `FileStorageS3` destructured `endpoint` from setup but never forwarded it to `new S3({...})`, so requests always hit AWS regardless of the configured endpoint. This is the actual blocker reported in #112 — extending the region regex alone wouldn't have made OVH work.
- The type-level XOR between `region` and `endpoint` is dropped; both can now be passed together (SigV4 always needs a region anyway). The "at least one of" constraint is preserved via a union.
- `extractRegionFromEndpoint` now recognizes OVH Object Storage (`s3.<region>.cloud.ovh.net` and `s3.<region>.perf.cloud.ovh.net`) and DigitalOcean Spaces (`<region>.digitaloceanspaces.com`) in addition to AWS (both plain and `<bucket>.s3.<region>.amazonaws.com` forms).
- New `forcePathStyle` setup option forwarded to the S3 client for MinIO-like providers.
- New unit spec `file-storage-s3.unit.spec.ts` (16 tests, no live credentials required) covering extraction cases and constructor wiring.

Closes #112

## Test plan

- [x] `npx nx test file-storage --testPathPattern=file-storage-s3.unit` — 16/16 passing
- [ ] Manual verification against a real OVH Object Storage bucket
- [ ] Manual verification against DigitalOcean Spaces
- [ ] AWS path still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)